### PR TITLE
support 10 fingers

### DIFF
--- a/drivers/input/touchscreen/qt602240.h
+++ b/drivers/input/touchscreen/qt602240.h
@@ -5275,7 +5275,7 @@ typedef struct
 } report_finger_info_t;
 
 //#define MAX_NUM_FINGER	10		// Maximum possible fingering
-#define MAX_USING_FINGER_NUM	5
+#define MAX_USING_FINGER_NUM	10
 #endif
 
   /* Each client has this additional data */


### PR DESCRIPTION
I don't know how this is relevant right now, but the kernel should allow it as CyanogenMod supports 10 fingers so I added support in the kernel drivers.

Phone is capable of 10, but samsung allows 5 in kernel drivers and 3 within the firmware.

CM has 10 in kernel and 10 in rom. (the change i made)
